### PR TITLE
BRZ-1101: Fix article series dropdown missing series with few articles

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -249,6 +249,21 @@ class Api
         return $options;
     }
 
+    /**
+     * @throws Exception
+     */
+    public function getArticleSeries()
+    {
+        $series  = $this->monkCms->get(['module' => 'series', 'display' => 'list', 'type' => 'article']);
+        $options = [];
+
+        foreach ($series['show'] as $serie) {
+            $options[$serie['slug']] = $serie['title'];
+        }
+
+        return $options;
+    }
+
 	public function getPrayer($query)
 	{
 		if (!$this->prayerCloudApi) {
@@ -318,7 +333,7 @@ class Api
 				$data = $this->getSeries('sermon');
 				break;
 			case 'articleSeries':
-				$data = $this->getSeries('article');
+				$data = $this->getArticleSeries();
 				break;
 			case 'articlesLvl':
 				$data = $this->getCatsLevels('article');


### PR DESCRIPTION
The getSeries('article') method queried module=article with groupby=series, which returns series only from the paginated article list. With a default article limit, series with few articles (e.g. "Calvary's Latest" with 1 article) were dropped from group_show when dominated by high-volume series.

Added getArticleSeries() that queries module=series,type=article directly — the same pattern already used by getGroupSeries() for group series — so all article series are returned regardless of their article count.