### PR TITLE
Prefetch placeholder queries in one parallel burst

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "require": {
     "php": ">=5.6.0",
     "twig/twig": "^1.0||^2.0",
-    "brizybuilder/monkcms-php": "^1.0",
+    "brizybuilder/monkcms-php": "^1.1",
     "brizybuilder/content-placeholder": "^3.0",
     "kigkonsult/icalcreator": "^2.39"
   },

--- a/src/MonkCms.php
+++ b/src/MonkCms.php
@@ -27,6 +27,18 @@ class MonkCms
      */
     private $apiUrl;
 
+    /**
+     * Request-scoped response cache, keyed by canonical query.
+     *
+     * @var array
+     */
+    private $cache = [];
+
+    /**
+     * @var Cms|null
+     */
+    private $cms;
+
     public function __construct(EkklesiaConfig $config)
     {
         $this->config = $config;
@@ -37,14 +49,74 @@ class MonkCms
      */
     public function get($args = [])
     {
+        $key = $this->cacheKey($args);
+
+        if (array_key_exists($key, $this->cache)) {
+            return $this->cache[$key];
+        }
+
+        return $this->cache[$key] = $this->getCms()->get($args);
+    }
+
+    /**
+     * Fetch multiple queries in parallel and warm the response cache.
+     *
+     * Queries already cached are skipped. Failed queries are left uncached,
+     * so a later `get()` retries them sequentially.
+     *
+     * @param array[] $queries List of query params arrays, same format as `get()`.
+     */
+    public function prefetch(array $queries)
+    {
+        $pending = [];
+
+        foreach ($queries as $args) {
+            if (!is_array($args) || !$args) {
+                continue;
+            }
+
+            $key = $this->cacheKey($args);
+
+            if (!array_key_exists($key, $this->cache) && !isset($pending[$key])) {
+                $pending[$key] = $args;
+            }
+        }
+
+        if (!$pending) {
+            return;
+        }
+
+        try {
+            $results = $this->getCms()->getMultiple($pending);
+        } catch (\Exception $e) {
+            return;
+        }
+
+        foreach ($results as $key => $result) {
+            $this->cache[$key] = $result;
+        }
+    }
+
+    private function getCms(): Cms
+    {
+        if ($this->cms !== null) {
+            return $this->cms;
+        }
+
         $config = $this->config->toArray();
 
         if (isset($config['url']) && empty($config['url'])) {
             unset($config['url']);
         }
 
-        $cms = new Cms($config, ['timeout' => 40]);
+        return $this->cms = new Cms($config, ['timeout' => 40]);
+    }
 
-        return $cms->get($args);
+    private function cacheKey($args): string
+    {
+        $args = array_filter((array)$args);
+        ksort($args);
+
+        return md5(serialize($args));
     }
 }

--- a/src/Placeholder/ArticleDetailPlaceholder.php
+++ b/src/Placeholder/ArticleDetailPlaceholder.php
@@ -5,9 +5,56 @@ namespace BrizyEkklesia\Placeholder;
 use BrizyPlaceholders\ContentPlaceholder;
 use BrizyPlaceholders\ContextInterface;
 
-class ArticleDetailPlaceholder extends PlaceholderAbstract
+class ArticleDetailPlaceholder extends PlaceholderAbstract implements PrefetchableInterface
 {
     const NAME = 'ekk_article_detail';
+
+    public function getPrefetchQueries(ContentPlaceholder $placeholder): array
+    {
+        $settings = array_merge([
+            'show_image'                => true,
+            'show_video'                => false,
+            'show_audio'                => false,
+            'show_media_links_video'    => false,
+            'show_media_links_audio'    => false,
+            'show_media_links_download' => false,
+            'show_media_links_notes'    => false,
+            'show_title'                => true,
+            'show_date'                 => true,
+            'show_category'             => true,
+            'show_group'                => false,
+            'show_series'               => false,
+            'show_author'               => true,
+            'show_meta_headings'        => false,
+            'show_content'              => false,
+            'articles_recent'           => '',
+            'previous_page'             => false,
+            'show_meta_icons'           => false,
+        ], $placeholder->getAttributes());
+
+        $slug = empty($_GET['mc-slug']) ? $settings['articles_recent'] : $_GET['mc-slug'];
+
+        if (!$slug) {
+            return [
+                [
+                    'module'      => 'article',
+                    'display'     => 'list',
+                    'order'       => 'recent',
+                    'howmany'     => 1,
+                    'emailencode' => 'no',
+                ],
+            ];
+        }
+
+        return [
+            [
+                'module'      => 'article',
+                'display'     => 'detail',
+                'find'        => $slug,
+                'emailencode' => 'no',
+            ],
+        ];
+    }
 
     public function echoValue(ContextInterface $context, ContentPlaceholder $placeholder)
     {

--- a/src/Placeholder/ArticleFeaturedPlaceholder.php
+++ b/src/Placeholder/ArticleFeaturedPlaceholder.php
@@ -6,11 +6,67 @@ use BrizyEkklesia\HelperTrait;
 use BrizyPlaceholders\ContentPlaceholder;
 use BrizyPlaceholders\ContextInterface;
 
-class ArticleFeaturedPlaceholder extends PlaceholderAbstract
+class ArticleFeaturedPlaceholder extends PlaceholderAbstract implements PrefetchableInterface
 {
     use HelperTrait;
 
     const NAME = 'ekk_article_featured';
+
+    public function getPrefetchQueries(ContentPlaceholder $placeholder): array
+    {
+        $settings = array_merge([
+            'show_image'              => true,
+            'show_video'              => false,
+            'show_audio'              => false,
+            'show_media_links'        => false,
+            'show_title'              => true,
+            'show_date'               => true,
+            'show_category'           => true,
+            'show_group'              => false,
+            'show_series'             => false,
+            'show_author'             => true,
+            'show_meta_headings'      => false,
+            'show_meta_icons'         => false,
+            'show_preview'            => false,
+            'show_content'            => false,
+            'detail_page_button_text' => '',
+            'detail_page'             => '',
+            'article_slug'            => '',
+            'recentArticles'          => '',
+            'features'                => '',
+            'nonfeatures'             => '',
+            'series'                  => 'all',
+            'category'                => 'all',
+            'group'                   => 'all',
+            'show_latest_articles'    => true,
+        ], $placeholder->getAttributes());
+
+        if ($settings['show_latest_articles']) {
+            return [
+                [
+                    'module'        => 'article',
+                    'display'       => 'list',
+                    'order'         => 'recent',
+                    'howmany'       => 1,
+                    'find_category' => $settings['category'] != 'all' ? $settings['category'] : '',
+                    'find_group'    => $settings['group'] != 'all' ? $settings['group'] : '',
+                    'find_series'   => $settings['series'] != 'all' ? $settings['series'] : '',
+                    'features'      => $settings['nonfeatures'] ? '' : $settings['features'],
+                    'nonfeatures'   => $settings['features'] ? '' : $settings['nonfeatures'],
+                    'emailencode'   => 'no',
+                ],
+            ];
+        }
+
+        return [
+            [
+                'module'      => 'article',
+                'display'     => 'detail',
+                'find'        => $settings['recentArticles'] ?: $settings['article_slug'],
+                'emailencode' => 'no',
+            ],
+        ];
+    }
 
     public function echoValue(ContextInterface $context, ContentPlaceholder $placeholder)
     {

--- a/src/Placeholder/ArticleLayoutPlaceholder.php
+++ b/src/Placeholder/ArticleLayoutPlaceholder.php
@@ -6,11 +6,94 @@ use BrizyEkklesia\HelperTrait;
 use BrizyPlaceholders\ContentPlaceholder;
 use BrizyPlaceholders\ContextInterface;
 
-class ArticleLayoutPlaceholder extends PlaceholderAbstract
+class ArticleLayoutPlaceholder extends PlaceholderAbstract implements PrefetchableInterface
 {
     use HelperTrait;
 
     const NAME = 'ekk_article_layout';
+
+    public function getPrefetchQueries(ContentPlaceholder $placeholder): array
+    {
+        $options = [
+            'show_category'                => false,
+            'parent_category'              => 'articles',
+            'show_category_filter'         => true,
+            'category_filter_parent'       => 'childrens-ministry',
+            'category_filter_heading'      => 'Category',
+            'show_category_filter_add1'    => false,
+            'category_filter_parent_add1'  => '',
+            'category_filter_heading_add1' => 'Category',
+            'show_category_filter_add2'    => false,
+            'category_filter_parent_add2'  => '',
+            'category_filter_heading_add2' => 'Category',
+            'show_category_filter_add3'    => false,
+            'category_filter_parent_add3'  => '',
+            'category_filter_heading_add3' => 'Category',
+            'show_group_filter'            => true,
+            'group_filter_heading'         => 'Group',
+            'show_search'                  => true,
+            'search_placeholder'           => 'Search',
+            'show_pagination'              => true,
+            'show_series_filter'           => true,
+            'series_filter_heading'        => 'Series',
+            'show_author_filter'           => true,
+            'author_filter_heading'        => 'Author',
+            'howmany'                      => 3,
+            'show_images'                  => true,
+            'show_video'                   => false,
+            'show_audio'                   => false,
+            'show_media_links'             => false,
+            'show_title'                   => true,
+            'show_date'                    => false,
+            'show_group'                   => false,
+            'show_series'                  => false,
+            'show_author'                  => false,
+            'show_meta_headings'           => false,
+            'show_preview'                 => false,
+            'detail_page_button_text'      => '',
+            'detail_page'                  => '',
+            'show_meta_icons'        => false
+        ];
+
+        $settings        = array_merge($options, $placeholder->getAttributes());
+        $parent_category = $settings['parent_category'];
+
+        $queries = [
+            ['module' => 'article', 'display' => 'categories'],
+            ['module' => 'article', 'display' => 'categories', 'parent_category' => $parent_category,],
+            ['module' => 'article', 'display' => 'list', 'groupby' => 'group', 'find_parent_category' => $parent_category,],
+            ['module' => 'article', 'display' => 'list', 'groupby' => 'series', 'find_parent_category' => $parent_category,],
+            ['module' => 'article', 'display' => 'list', 'groupby' => 'author', 'find_parent_category' => $parent_category,],
+        ];
+
+        if (isset($_GET['mc-search_term'])) {
+            $queries[] = [
+                'module'        => 'search',
+                'display'       => 'results',
+                'howmany'       => '100',
+                'find_category' => $parent_category,
+                'keywords'      => $_GET['mc-search_term'],
+                'find_module'   => 'article',
+                'hide_module'   => 'media',
+            ];
+        } else {
+            $queries[] = [
+                'module'               => 'article',
+                'display'              => 'list',
+                'order'                => 'recent',
+                'emailencode'          => 'no',
+                'howmany'              => '100',
+                'find_parent_category' => $parent_category,
+                'find_group'           => isset($_GET['mc-group']) ? $_GET['mc-group'] : '',
+                'find_series'          => isset($_GET['mc-series']) ? $_GET['mc-series'] : '',
+                'find_author'          => isset($_GET['mc-author']) ? $_GET['mc-author'] : '',
+                'show'                 => "__videoplayer fullscreen='true'__",
+                'show'                 => "__audioplayer__",
+            ];
+        }
+
+        return $queries;
+    }
 
     public function echoValue(ContextInterface $context, ContentPlaceholder $placeholder)
     {

--- a/src/Placeholder/ArticleListPlaceholder.php
+++ b/src/Placeholder/ArticleListPlaceholder.php
@@ -6,11 +6,58 @@ use BrizyEkklesia\HelperTrait;
 use BrizyPlaceholders\ContentPlaceholder;
 use BrizyPlaceholders\ContextInterface;
 
-class ArticleListPlaceholder extends PlaceholderAbstract
+class ArticleListPlaceholder extends PlaceholderAbstract implements PrefetchableInterface
 {
     use HelperTrait;
 
     const NAME = 'ekk_article_list';
+
+    public function getPrefetchQueries(ContentPlaceholder $placeholder): array
+    {
+        $options = [
+            'category'                => '',
+            'group'                   => '',
+            'series'                  => '',
+            'howmany'                 => 3,
+            'show_pagination'         => false,
+            'features'                => '',
+            'nonfeatures'             => '',
+            'show_images'             => true,
+            'show_video'              => false,
+            'show_audio'              => false,
+            'show_media_links'        => false,
+            'show_title'              => true,
+            'show_date'               => false,
+            'show_category'           => false,
+            'show_group'              => false,
+            'show_series'             => false,
+            'show_author'             => false,
+            'show_meta_headings'      => false,
+            'show_preview'            => false,
+            'detail_page_button_text' => '',
+            'detail_page'             => '',
+            'show_meta_icons'         => false,
+        ];
+
+        $settings = array_merge($options, $placeholder->getAttributes());
+
+        return [
+            [
+                'module'        => 'article',
+                'display'       => 'list',
+                'order'         => 'recent',
+                'emailencode'   => 'no',
+                'howmany'       => $settings['howmany'],
+                'page'          => isset($_GET['mc-page']) ? $_GET['mc-page'] : 1,
+                'find_category' => $settings['category'] != 'all' ? $settings['category'] : '',
+                'find_group'    => $settings['group'] != 'all' ? $settings['group'] : '',
+                'find_series'   => $settings['series'] != 'all' ? $settings['series'] : '',
+                'features'      => $settings['nonfeatures'] ? '' : $settings['features'],
+                'nonfeatures'   => $settings['features'] ? '' : $settings['nonfeatures'],
+                'after_show'    => '__pagination__',
+            ],
+        ];
+    }
 
     public function echoValue(ContextInterface $context, ContentPlaceholder $placeholder)
     {

--- a/src/Placeholder/EventCalendarPlaceholder.php
+++ b/src/Placeholder/EventCalendarPlaceholder.php
@@ -8,12 +8,62 @@ use DateInterval;
 use DatePeriod;
 use DateTime;
 
-class EventCalendarPlaceholder extends PlaceholderAbstract
+class EventCalendarPlaceholder extends PlaceholderAbstract implements PrefetchableInterface
 {
     const NAME = 'ekk_event_calendar';
 
     private $time = false;
     private $timeFormat = '24';
+
+    public function getPrefetchQueries(ContentPlaceholder $placeholder): array
+    {
+        $options = [
+            'category'                      => 'all',
+            'group'                         => 'all',
+            'features'                      => '',
+            'nonfeatures'                   => '',
+            'detail_page'                   => false,
+            'howmanymonths'                 => 3,
+            'time'                          => false,
+            'time_format'                   => '24',
+            'showSubscribeToCalendarButton' => false,
+        ];
+
+        $settings = array_merge($options, $placeholder->getAttributes());
+
+        $category      = $settings['category'] != 'all' ? $settings['category'] : '';
+        $group         = $settings['group'] != 'all' ? $settings['group'] : '';
+        $calendarStart = date('Y-m-d');
+        $calendarEnd   = date('Y-m-d', strtotime("+{$settings['howmanymonths']} months"));
+        $date1         = new DateTime($calendarStart);
+        $date2         = new DateTime($calendarEnd);
+        $diff          = $date1->diff($date2, true);
+        $calendarDays  = $diff->format('%a');
+        $features      = $settings['features'];
+        $nonfeatures   = $settings['nonfeatures'];
+
+        if ($features) {
+            $nonfeatures = '';
+        } elseif ($nonfeatures) {
+            $features = '';
+        }
+
+        return [
+            [
+                'module'        => 'event',
+                'display'       => 'list',
+                'emailencode'   => 'no',
+                'recurring'     => 'yes',
+                'repeatevent'   => 'yes',
+                'groupby'       => 'day',
+                'howmanydays'   => $calendarDays,
+                'find_category' => $category,
+                'find_group'    => $group,
+                'features'      => $features,
+                'nonfeatures'   => $nonfeatures,
+            ],
+        ];
+    }
 
     public function echoValue(ContextInterface $context, ContentPlaceholder $placeholder)
     {

--- a/src/Placeholder/EventDetailPlaceholder.php
+++ b/src/Placeholder/EventDetailPlaceholder.php
@@ -8,9 +8,63 @@ use Kigkonsult\Icalcreator\Vcalendar;
 use DateTime;
 use DateTimeZone;
 
-class EventDetailPlaceholder extends PlaceholderAbstract
+class EventDetailPlaceholder extends PlaceholderAbstract implements PrefetchableInterface
 {
     const NAME = 'ekk_event_detail';
+
+    public function getPrefetchQueries(ContentPlaceholder $placeholder): array
+    {
+        $options = [
+            'show_image'             => false,
+            'show_title'             => false,
+            'show_date'              => false,
+            'show_category'          => false,
+            'show_group'             => false,
+            'show_meta_headings'     => false,
+            'show_location'          => false,
+            'show_room'              => false,
+            'show_coordinator'       => false,
+            'show_coordinator_email' => false,
+            'show_coordinator_phone' => false,
+            'show_cost'              => false,
+            'show_website'           => false,
+            'show_registration'      => false,
+            'show_description'       => false,
+            'events_recent'          => false,
+            'previous_page'          => false,
+            'show_subscribe_to_event'=> false,
+            'subscribe_to_event_button_text' => '',
+            'show_meta_icons'        => false,
+            'date_format'            => 'g:i a'
+        ];
+
+        $settings = array_merge($options, $placeholder->getAttributes());
+
+        if (isset($_GET['mc-slug'])) {
+            $slug = $_GET['mc-slug'];
+        } elseif ($settings['events_recent']) {
+            $slug = $settings['events_recent'];
+        } else {
+            return [
+                [
+                    'module'      => 'event',
+                    'display'     => 'list',
+                    'order'       => 'recent',
+                    'emailencode' => 'no',
+                    'howmany'     => 1,
+                ],
+            ];
+        }
+
+        return [
+            [
+                'module'      => 'event',
+                'display'     => 'detail',
+                'emailencode' => 'no',
+                'find'        => $slug,
+            ],
+        ];
+    }
 
     public function echoValue(ContextInterface $context, ContentPlaceholder $placeholder)
     {

--- a/src/Placeholder/EventFeaturedPlaceholder.php
+++ b/src/Placeholder/EventFeaturedPlaceholder.php
@@ -6,11 +6,94 @@ use BrizyEkklesia\HelperTrait;
 use BrizyPlaceholders\ContentPlaceholder;
 use BrizyPlaceholders\ContextInterface;
 
-class EventFeaturedPlaceholder extends PlaceholderAbstract
+class EventFeaturedPlaceholder extends PlaceholderAbstract implements PrefetchableInterface
 {
     use HelperTrait;
 
     const NAME = 'ekk_event_featured';
+
+    public function getPrefetchQueries(ContentPlaceholder $placeholder): array
+    {
+        $options = [
+            'show_image'              => false,
+            'show_title'              => false,
+            'show_date'               => false,
+            'show_category'           => false,
+            'show_group'              => false,
+            'show_meta_headings'      => false,
+            'show_location'           => false,
+            'show_room'               => false,
+            'show_coordinator'        => false,
+            'show_coordinator_email'  => false,
+            'show_coordinator_phone'  => false,
+            'show_cost'               => false,
+            'show_website'            => false,
+            'show_registration'       => false,
+            'show_description'        => false,
+            'show_preview'            => false,
+            'show_latest_events'      => false,
+            'recentEvents'            => '',
+            'event_slug'              => false,
+            'category'                => 'all',
+            'group'                   => 'all',
+            'features'                => '',
+            'nonfeatures'             => '',
+            'detail_page_button_text' => false,
+            'detail_page'             => false,
+            'show_meta_icons'         => false,
+            'date_format'             => 'g:i a'
+        ];
+
+        $settings = array_merge($options, $placeholder->getAttributes());
+
+        $recentEvents = $settings['recentEvents'] != '' ? $settings['recentEvents'] : '';
+        $category     = $settings['category'] != 'all' ? $settings['category'] : '';
+        $group        = $settings['group'] != 'all' ? $settings['group'] : '';
+        $features     = $settings['features'];
+        $nonfeatures  = $settings['nonfeatures'];
+
+        if ($features) {
+            $nonfeatures = '';
+        } elseif ($nonfeatures) {
+            $features = '';
+        }
+
+        if ($settings['show_latest_events']) {
+            return [
+                [
+                    'module'        => 'event',
+                    'display'       => 'list',
+                    'order'         => 'recent',
+                    'howmany'       => 1,
+                    'find_category' => $category,
+                    'find_group'    => $group,
+                    'features'      => $features,
+                    'nonfeatures'   => $nonfeatures,
+                    'emailencode'   => 'no',
+                ],
+            ];
+        }
+
+        $slug = false;
+        if ($settings['event_slug']) {
+            $slug = $settings['event_slug'];
+        } elseif ($recentEvents != '') {
+            $slug = $recentEvents;
+        }
+
+        if ($slug) {
+            return [
+                [
+                    'module'      => 'event',
+                    'display'     => 'detail',
+                    'find'        => $slug,
+                    'emailencode' => 'no',
+                ],
+            ];
+        }
+
+        return [];
+    }
 
     public function echoValue(ContextInterface $context, ContentPlaceholder $placeholder)
     {

--- a/src/Placeholder/EventLayoutPlaceholder.php
+++ b/src/Placeholder/EventLayoutPlaceholder.php
@@ -11,11 +11,177 @@ use DateTime;
 use Exception;
 use ArrayIterator;
 
-class EventLayoutPlaceholder extends PlaceholderAbstract
+class EventLayoutPlaceholder extends PlaceholderAbstract implements PrefetchableInterface
 {
     use HelperTrait;
 
     const NAME = 'ekk_event_layout';
+
+    public function getPrefetchQueries(ContentPlaceholder $placeholder): array
+    {
+        $options = [
+            'show_featured_view'           => true,
+            'view_order_featured'          => 1,
+            'view_featured_heading'        => 'Featured Events',
+            'howmanyfeatured'              => 9,
+            'column_count_featured'        => 3,
+            'column_count_featured_tablet' => 2,
+            'column_count_featured_mobile' => 1,
+            'show_images_featured'         => true,
+            'show_title_featured'          => true,
+            'show_date_featured'           => true,
+            'show_preview_featured'        => true,
+            'show_list_view'               => true,
+            'view_order_list'              => 2,
+            'view_list_heading'            => 'Events List',
+            'show_calendar_view'           => true,
+            'view_order_calendar'          => 3,
+            'view_calendar_heading'        => 'Full Calendar',
+            'howmanymonths'                => 1,
+            'detail_page'                  => false,
+            'detail_page_button_text'      => '',
+            'sticky_space'                 => 0,
+            'parent_category'              => '',
+            'category_filter_list'         => '',
+            'category_filter_list_add1'    => '',
+            'category_filter_list_add2'    => '',
+            'category_filter_list_add3'    => '',
+            'show_category_filter'         => true,
+            'category_filter_parent'       => '',
+            'category_filter_heading'      => 'Category',
+            'show_category_filter_add1'    => false,
+            'category_filter_parent_add1'  => '',
+            'category_filter_heading_add1' => 'Category',
+            'show_category_filter_add2'    => false,
+            'category_filter_parent_add2'  => '',
+            'category_filter_heading_add2' => 'Category',
+            'show_category_filter_add3'    => true,
+            'category_filter_parent_add3'  => '',
+            'category_filter_heading_add3' => 'Category',
+            'show_group_filter'            => false,
+            'group_filter_heading'         => 'Group',
+            'show_search'                  => true,
+            'search_placeholder'           => 'Search',
+            'featuredActive'               => '',
+            'listActive'                   => '',
+            'calendarActive'               => '',
+            'date_format'                  => 'g:i a',
+            'group_slug'                   => '',
+        ];
+
+        $attrs    = $placeholder->getAttributes();
+        $settings = array_merge($options, $attrs);
+
+        $parent_category = $settings['parent_category'] ? [$settings['parent_category']] : [];
+        $calendarStart   = date('Y-m-d');
+        $calendarEnd     = date('Y-m-d', strtotime("+{$settings['howmanymonths']} months"));
+        $date1           = new DateTime($calendarStart);
+        $date2           = new DateTime($calendarEnd);
+        $diff            = $date1->diff($date2, true);
+        $calendarDays    = $diff->format('%a');
+        $requestGroup    = $_GET['mc-group'] ?? false;
+
+        if ($settings['category_filter_list']) {
+            $category_filter_list = preg_replace("/\s+/", "", $settings['category_filter_list']);
+            $category_filter_list = explode(",", $category_filter_list);
+            array_push($parent_category, ...$category_filter_list);
+        }
+
+        if ($settings['category_filter_list_add1']) {
+            $category_filter_list_add1 = preg_replace("/\s+/", "", $settings['category_filter_list_add1']);
+            $category_filter_list_add1 = explode(",", $category_filter_list_add1);
+            array_push($parent_category, ...$category_filter_list_add1);
+        }
+
+        if ($settings['category_filter_list_add2']) {
+            $category_filter_list_add2 = preg_replace("/\s+/", "", $settings['category_filter_list_add2']);
+            $category_filter_list_add2 = explode(",", $category_filter_list_add2);
+            array_push($parent_category, ...$category_filter_list_add2);
+        }
+
+        if ($settings['category_filter_list_add3']) {
+            $category_filter_list_add3 = preg_replace("/\s+/", "", $settings['category_filter_list_add3']);
+            $category_filter_list_add3 = explode(",", $category_filter_list_add3);
+            array_push($parent_category, ...$category_filter_list_add3);
+        }
+
+        $parent_category = $parent_category ? implode(",", $parent_category) : '';
+
+        if (isset($_GET['mc-view'])) {
+            $view = $_GET['mc-view'];
+        } else {
+            $orderArr = [];
+            if ($settings['show_featured_view']) {
+                $orderArr[$settings['view_order_featured']] = "featured";
+            }
+            if ($settings['show_list_view']) {
+                $orderArr[$settings['view_order_list']] = "list";
+            }
+            if ($settings['show_calendar_view']) {
+                $orderArr[$settings['view_order_calendar']] = "calendar";
+            }
+            ksort($orderArr);
+            $orderArr = array_unique($orderArr);
+            $view     = reset($orderArr);
+        }
+
+        $queries = [];
+
+        $queries[] = [
+            'module'     => 'event',
+            'display'    => 'categories',
+            'find_group' => $settings['group_slug'] ?: $requestGroup,
+        ];
+
+        $queries[] = [
+            'module'          => 'event',
+            'display'         => 'categories',
+            'parent_category' => $parent_category,
+        ];
+
+        if ($settings['show_group_filter']) {
+            $queries[] = [
+                'module'  => 'group',
+                'display' => 'list',
+            ];
+        }
+
+        if (isset($_GET['mc-search'])) {
+            $queries[] = [
+                'module'        => 'search',
+                'display'       => 'results',
+                'howmany'       => $settings['howmanyfeatured'],
+                'find_category' => $parent_category,
+                'keywords'      => $_GET['mc-search'],
+                'find_module'   => 'event',
+                'hide_module'   => 'media',
+                'after_show'    => '__pagination__',
+            ];
+        } elseif ($view == "featured") {
+            $queries[] = [
+                'module'               => 'event',
+                'display'              => 'list',
+                'emailencode'          => 'no',
+                'features'             => 'features',
+                'howmany'              => $settings['howmanyfeatured'],
+                'find_parent_category' => $parent_category,
+            ];
+        } else {
+            $queries[] = [
+                'module'               => 'event',
+                'display'              => 'list',
+                'emailencode'          => 'no',
+                'recurring'            => 'yes',
+                'repeatevent'          => 'yes',
+                'groupby'              => 'day',
+                'howmanydays'          => $calendarDays,
+                'find_parent_category' => $parent_category,
+                'find_group'           => $settings['group_slug'] ?: $requestGroup,
+            ];
+        }
+
+        return $queries;
+    }
 
     public function echoValue(ContextInterface $context, ContentPlaceholder $placeholder)
     {

--- a/src/Placeholder/EventListPlaceholder.php
+++ b/src/Placeholder/EventListPlaceholder.php
@@ -6,11 +6,70 @@ use BrizyEkklesia\HelperTrait;
 use BrizyPlaceholders\ContentPlaceholder;
 use BrizyPlaceholders\ContextInterface;
 
-class EventListPlaceholder extends PlaceholderAbstract
+class EventListPlaceholder extends PlaceholderAbstract implements PrefetchableInterface
 {
     use HelperTrait;
 
     const NAME = 'ekk_event_list';
+
+    public function getPrefetchQueries(ContentPlaceholder $placeholder): array
+    {
+        $options = [
+            'show_images'             => false,
+            'show_title'              => false,
+            'show_date'               => false,
+            'show_category'           => false,
+            'show_group'              => false,
+            'show_meta_headings'      => false,
+            'category'                => 'all',
+            'group'                   => 'all',
+            'features'                => '',
+            'nonfeatures'             => '',
+            'show_preview'            => false,
+            'detail_page_button_text' => '',
+            'detail_page'             => false,
+            'howmany'                 => 9,
+            'column_count'            => 3,
+            'column_count_tablet'     => 2,
+            'column_count_mobile'     => 1,
+            'show_pagination'         => false,
+            'show_location'           => false,
+            'show_registration'       => false,
+            'sticky_space'            => 0,
+            'show_meta_icons'         => false,
+            'date_format'             => 'g:i a'
+        ];
+
+        $settings = array_merge($options, $placeholder->getAttributes());
+
+        $category    = $settings['category'] != 'all' ? $settings['category'] : '';
+        $group       = $settings['group'] != 'all' ? $settings['group'] : '';
+        $page        = isset($_GET['mc-page']) ? $_GET['mc-page'] : 1;
+        $features    = $settings['features'];
+        $nonfeatures = $settings['nonfeatures'];
+
+        if ($features) {
+            $nonfeatures = '';
+        } elseif ($nonfeatures) {
+            $features = '';
+        }
+
+        return [
+            [
+                'module'        => 'event',
+                'display'       => 'list',
+                'order'         => 'recent',
+                'emailencode'   => 'no',
+                'howmany'       => $settings['howmany'],
+                'page'          => $page,
+                'find_category' => $category,
+                'find_group'    => $group,
+                'features'      => $features,
+                'nonfeatures'   => $nonfeatures,
+                'after_show'    => '__pagination__'
+            ],
+        ];
+    }
 
     public function echoValue(ContextInterface $context, ContentPlaceholder $placeholder)
     {

--- a/src/Placeholder/FormPlaceholder.php
+++ b/src/Placeholder/FormPlaceholder.php
@@ -5,9 +5,33 @@ namespace BrizyEkklesia\Placeholder;
 use BrizyPlaceholders\ContentPlaceholder;
 use BrizyPlaceholders\ContextInterface;
 
-class FormPlaceholder extends PlaceholderAbstract
+class FormPlaceholder extends PlaceholderAbstract implements PrefetchableInterface
 {
     const NAME = 'ekk_form';
+
+    public function getPrefetchQueries(ContentPlaceholder $placeholder): array
+    {
+        $atts = $placeholder->getAttributes();
+
+        if (empty($atts['form'])) {
+            return [];
+        }
+
+        $isEditor = strpos($_SERVER['REQUEST_URI'], 'placeholders_bulks') || (isset($_POST['action']) && $_POST['action'] == 'brizy_placeholders_content');
+
+        if ($isEditor) {
+            return [];
+        }
+
+        return [
+            [
+                'module'  => 'fmsform',
+                'display' => 'detail',
+                'find_id' => $atts['form'],
+                'show'    => '__embedhtml__'
+            ]
+        ];
+    }
 
     public function echoValue(ContextInterface $context, ContentPlaceholder $placeholder)
     {

--- a/src/Placeholder/GroupDetailPlaceholder.php
+++ b/src/Placeholder/GroupDetailPlaceholder.php
@@ -5,9 +5,58 @@ namespace BrizyEkklesia\Placeholder;
 use BrizyPlaceholders\ContentPlaceholder;
 use BrizyPlaceholders\ContextInterface;
 
-class GroupDetailPlaceholder extends PlaceholderAbstract
+class GroupDetailPlaceholder extends PlaceholderAbstract implements PrefetchableInterface
 {
 	const NAME = 'ekk_group_detail';
+
+	public function getPrefetchQueries(ContentPlaceholder $placeholder): array
+	{
+		$options = [
+			'show_image'         => false,
+			'show_title'         => false,
+			'show_category'      => false,
+			'show_group'         => false,
+			'show_meta_headings' => false,
+			'show_day'           => false,
+			'show_times'         => false,
+			'show_status'        => false,
+			'show_childcare'     => false,
+			'show_resourcelink'  => false,
+			'show_content'       => false,
+			'groups_recent'      => false,
+			'previous_page'      => false,
+            'show_meta_icons'    => false,
+			'date_format' 		 => 'g:i a'
+		];
+
+		$settings = array_merge($options, $placeholder->getAttributes());
+
+		if (isset($_GET['mc-slug'])) {
+			$slug = $_GET['mc-slug'];
+		} elseif ($settings['groups_recent']) {
+			$slug = $settings['groups_recent'];
+		} else {
+			return [
+				[
+					'module'      => 'smallgroup',
+					'display'     => 'list',
+					'order'       => 'recent',
+					'howmany'     => 1,
+					'emailencode' => 'no',
+				],
+			];
+		}
+
+		return [
+			[
+				'module'      => 'smallgroup',
+				'display'     => 'detail',
+				'find'        => $slug,
+				'show'        => "__endtime format='g:ia'__",
+				'emailencode' => 'no',
+			],
+		];
+	}
 
 	public function echoValue(ContextInterface $context, ContentPlaceholder $placeholder)
 	{

--- a/src/Placeholder/GroupFeaturedPlaceholder.php
+++ b/src/Placeholder/GroupFeaturedPlaceholder.php
@@ -5,9 +5,75 @@ namespace BrizyEkklesia\Placeholder;
 use BrizyPlaceholders\ContentPlaceholder;
 use BrizyPlaceholders\ContextInterface;
 
-class GroupFeaturedPlaceholder extends PlaceholderAbstract
+class GroupFeaturedPlaceholder extends PlaceholderAbstract implements PrefetchableInterface
 {
     const NAME = 'ekk_group_featured';
+
+    public function getPrefetchQueries(ContentPlaceholder $placeholder): array
+    {
+        $options = [
+            'show_title'              => false,
+            'show_image'              => false,
+            'show_category'           => false,
+            'show_group'              => false,
+            'show_day'                => false,
+            'show_times'              => false,
+            'show_status'             => false,
+            'show_childcare'          => false,
+            'show_resourcelink'       => false,
+            'show_preview'            => false,
+            'group_latest'            => false,
+            'group_recent_list'       => false,
+            'group_slug'              => false,
+            'category'                => 'all',
+            'group'                   => 'all',
+            'detail_page_button_text' => false,
+            'detail_page'             => false,
+            'slug'                    => false,
+            'show_meta_icons'         => false,
+            'date_format'             => 'g:i a'
+        ];
+
+        $settings = array_merge($options, $placeholder->getAttributes());
+
+        $group_recent_list = $settings['group_recent_list'] != 'none' ? $settings['group_recent_list'] : '';
+        $category          = $settings['category'] != 'all' ? $settings['category'] : '';
+        $group             = $settings['group'] != 'all' ? $settings['group'] : '';
+
+        $queries = [];
+        $slug    = $settings['slug'];
+
+        if ($settings['group_latest']) {
+            $queries[] = [
+                'module'        => 'smallgroup',
+                'display'       => 'list',
+                'order'         => 'recent',
+                'howmany'       => 1,
+                'find_category' => $category,
+                'find_group'    => $group,
+                'emailencode'   => 'no',
+                'show'          => "__endtime format='g:ia'__",
+            ];
+        } else {
+            if ($settings['group_slug']) {
+                $slug = $settings['group_slug'];
+            } elseif ($group_recent_list != '') {
+                $slug = $group_recent_list;
+            }
+        }
+
+        if (!empty($slug)) {
+            $queries[] = [
+                'module'      => 'smallgroup',
+                'display'     => 'detail',
+                'find'        => $slug,
+                'emailencode' => 'no',
+                'show'        => "__endtime format='g:ia'__",
+            ];
+        }
+
+        return $queries;
+    }
 
     public function echoValue(ContextInterface $context, ContentPlaceholder $placeholder)
     {

--- a/src/Placeholder/GroupLayoutPlaceholder.php
+++ b/src/Placeholder/GroupLayoutPlaceholder.php
@@ -6,11 +6,101 @@ use BrizyEkklesia\HelperTrait;
 use BrizyPlaceholders\ContentPlaceholder;
 use BrizyPlaceholders\ContextInterface;
 
-class GroupLayoutPlaceholder extends PlaceholderAbstract
+class GroupLayoutPlaceholder extends PlaceholderAbstract implements PrefetchableInterface
 {
     use HelperTrait;
 
     const NAME = 'ekk_group_layout';
+
+    public function getPrefetchQueries(ContentPlaceholder $placeholder): array
+    {
+        $options = [
+            'show_category'                   => true,
+            'parent_category'                 => '',
+            'show_category_filter'            => true,
+            'category_filter_parent'          => true,
+            'category_filter_heading'         => 'Category',
+            'show_category_filter_add1'       => false,
+            'category_filter_parent_add1'     => '',
+            'category_filter_heading_add1'    => 'Category',
+            'show_category_filter_add2'       => false,
+            'category_filter_parent_add2'     => '',
+            'category_filter_heading_add2'    => 'Category',
+            'show_category_filter_add3'       => true,
+            'category_filter_parent_add3'     => '',
+            'category_filter_heading_add3'    => 'Category',
+            'show_group_filter'               => true,
+            'group_filter_heading'            => 'Group',
+            'show_search'                     => true,
+            'search_placeholder'              => 'Search',
+            'show_pagination'                 => true,
+            'howmany'                         => 9,
+            'column_count'                    => 3,
+            'column_count_tablet'             => 2,
+            'column_count_mobile'             => 1,
+            'show_images'                     => true,
+            'show_day'                        => true,
+            'show_times'                      => true,
+            'show_group'                      => true,
+            'show_status'                     => true,
+            'show_childcare'                  => true,
+            'show_resourcelink'               => true,
+            'show_preview'                    => true,
+            'detail_page_button_text'         => false,
+            'sticky_space'                    => 0,
+            'detail_page'                     => false,
+            'show_meta_icons'                 => false,
+            'date_format'                     => 'g:i a',
+            'group_slug'                      => ''
+        ];
+
+        $settings = array_merge($options, $placeholder->getAttributes());
+
+        $requestGroup = $_GET['mc-group'] ?? false;
+
+        $queries = [
+            [
+                'module'     => 'smallgroup',
+                'display'    => 'categories',
+                'find_group' => $settings['group_slug'] ?: $requestGroup
+            ],
+            [
+                'module'          => 'smallgroup',
+                'display'         => 'categories',
+                'parent_category' => $settings['parent_category'],
+            ],
+            [
+                'module'  => 'smallgroup',
+                'display' => 'list',
+                'groupby' => 'group'
+            ],
+        ];
+
+        if (isset($_GET['mc-search'])) {
+            $queries[] = [
+                'module'        => 'search',
+                'display'       => 'results',
+                'howmany'       => '100',
+                'find_category' => $settings['parent_category'],
+                'keywords'      => $_GET['mc-search'],
+                'find_module'   => 'smallgroup',
+                'hide_module'   => 'media',
+            ];
+        } else {
+            $queries[] = [
+                'module'        => 'smallgroup',
+                'display'       => 'list',
+                'order'         => 'recent',
+                'emailencode'   => 'no',
+                'howmany'       => '100',
+                'find_category' => $settings['parent_category'],
+                'find_group'    => $settings['group_slug'] ?: $requestGroup,
+                'show'          => "__endtime format='g:ia'__",
+            ];
+        }
+
+        return $queries;
+    }
 
     public function echoValue(ContextInterface $context, ContentPlaceholder $placeholder)
     {

--- a/src/Placeholder/GroupListPlaceholder.php
+++ b/src/Placeholder/GroupListPlaceholder.php
@@ -6,11 +6,57 @@ use BrizyEkklesia\HelperTrait;
 use BrizyPlaceholders\ContentPlaceholder;
 use BrizyPlaceholders\ContextInterface;
 
-class GroupListPlaceholder extends PlaceholderAbstract
+class GroupListPlaceholder extends PlaceholderAbstract implements PrefetchableInterface
 {
     use HelperTrait;
 
     const NAME = 'ekk_group_list';
+
+    public function getPrefetchQueries(ContentPlaceholder $placeholder): array
+    {
+        $options = [
+            'show_image'                      => false,
+            'show_category'                   => false,
+            'show_group'                      => false,
+            'show_coordinator'                => false,
+            'category'                        => 'all',
+            'group'                           => 'all',
+            'show_preview'                    => false,
+            'detail_page_button_text'         => '',
+            'detail_page'                     => '',
+            'howmany'                         => 9,
+            'column_count'                    => 3,
+            'column_count_tablet'             => 2,
+            'column_count_mobile'             => 1,
+            'show_pagination'                 => false,
+            'show_images'                     => false,
+            'show_day'                        => false,
+            'show_times'                      => false,
+            'show_status'                     => false,
+            'show_childcare'                  => false,
+            'show_resourcelink'               => false,
+            'sticky_space'                    => 0,
+            'show_meta_icons'                 => false,
+            'date_format'                     => 'g:i a'
+        ];
+
+        $settings = array_merge($options, $placeholder->getAttributes());
+
+        return [
+            [
+                'module'        => 'smallgroup',
+                'display'       => 'list',
+                'order'         => 'recent',
+                'emailencode'   => 'no',
+                'howmany'       => $settings['howmany'],
+                'page'          => isset($_GET['mc-page']) ? $_GET['mc-page'] : 1,
+                'find_category' => $settings['category'] == 'all' ? '' : $settings['category'],
+                'find_group'    => $settings['group'] == 'all' ? '' : $settings['group'],
+                'show'          => "__endtime format='g:ia'__",
+                'after_show'    => '__pagination__'
+            ],
+        ];
+    }
 
     public function echoValue(ContextInterface $context, ContentPlaceholder $placeholder)
     {

--- a/src/Placeholder/GroupSliderPlaceholder.php
+++ b/src/Placeholder/GroupSliderPlaceholder.php
@@ -6,11 +6,54 @@ use BrizyEkklesia\HelperTrait;
 use BrizyPlaceholders\ContentPlaceholder;
 use BrizyPlaceholders\ContextInterface;
 
-class GroupSliderPlaceholder extends PlaceholderAbstract
+class GroupSliderPlaceholder extends PlaceholderAbstract implements PrefetchableInterface
 {
     use HelperTrait;
 
     const NAME = 'ekk_group_slider';
+
+    public function getPrefetchQueries(ContentPlaceholder $placeholder): array
+    {
+        $options = [
+            'show_image'                      => false,
+            'show_category'                   => false,
+            'show_group'                      => false,
+            'category'                        => 'all',
+            'group'                           => 'all',
+            'show_preview'                    => false,
+            'detail_page_button_text'         => false,
+            'detail_page'                     => false,
+            'howmany'                         => 9,
+            'column_count'                    => 3,
+            'show_pagination'                 => false,
+            'show_images'                     => false,
+            'show_day'                        => false,
+            'show_times'                      => false,
+            'show_status'                     => false,
+            'show_childcare'                  => false,
+            'show_resourcelink'               => false,
+            'howmany_show'                    => 3,
+            'show_arrows'                     => false,
+            'show_meta_icons'                 => false,
+            'date_format'                     => 'g:i a'
+        ];
+
+        $settings = array_merge($options, $placeholder->getAttributes());
+
+        return [
+            [
+                'module'        => 'smallgroup',
+                'display'       => 'list',
+                'order'         => 'recent',
+                'emailencode'   => 'no',
+                'howmany'       => $settings['howmany'],
+                'page'          => isset($_GET['mc-page']) ? $_GET['mc-page'] : 1,
+                'find_category' => $settings['category'] == 'all' ? '' : $settings['category'],
+                'find_group'    => $settings['group'] == 'all' ? '' : $settings['group'],
+                'show'          => "__endtime format='g:ia'__"
+            ],
+        ];
+    }
 
     public function echoValue(ContextInterface $context, ContentPlaceholder $placeholder)
     {

--- a/src/Placeholder/PlaceholderAbstract.php
+++ b/src/Placeholder/PlaceholderAbstract.php
@@ -70,6 +70,11 @@ abstract class PlaceholderAbstract extends AbstractPlaceholder
         return $this->group;
     }
 
+    public function getMonkCms(): MonkCms
+    {
+        return $this->monkCMS;
+    }
+
 	public function getConfigStructure()
 	{
 		// TODO: Implement getConfigStructure() method.

--- a/src/Placeholder/PrayerPlaceholder.php
+++ b/src/Placeholder/PrayerPlaceholder.php
@@ -5,9 +5,21 @@ namespace BrizyEkklesia\Placeholder;
 use BrizyPlaceholders\ContentPlaceholder;
 use BrizyPlaceholders\ContextInterface;
 
-class PrayerPlaceholder extends PlaceholderAbstract
+class PrayerPlaceholder extends PlaceholderAbstract implements PrefetchableInterface
 {
     const NAME = 'ekk_prayer';
+
+    public function getPrefetchQueries(ContentPlaceholder $placeholder): array
+    {
+        return [
+            [
+                'module'  => 'fmsform',
+                'display' => 'detail',
+                'find'    => 'prayer-request',
+                'show'    => '__embedhtml__'
+            ]
+        ];
+    }
 
     public function echoValue(ContextInterface $context, ContentPlaceholder $placeholder)
     {

--- a/src/Placeholder/PrefetchableInterface.php
+++ b/src/Placeholder/PrefetchableInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace BrizyEkklesia\Placeholder;
+
+use BrizyPlaceholders\ContentPlaceholder;
+
+interface PrefetchableInterface
+{
+    /**
+     * MonkCMS queries this placeholder will run while rendering, derivable
+     * before render time. Queries whose params depend on another API response
+     * must not be returned — they will run sequentially on cache miss.
+     *
+     * @return array[] List of query params arrays, same format as MonkCms::get().
+     */
+    public function getPrefetchQueries(ContentPlaceholder $placeholder): array;
+
+    public function getMonkCms(): \BrizyEkklesia\MonkCms;
+}

--- a/src/Placeholder/SermonDetailPlaceholder.php
+++ b/src/Placeholder/SermonDetailPlaceholder.php
@@ -5,9 +5,65 @@ namespace BrizyEkklesia\Placeholder;
 use BrizyPlaceholders\ContentPlaceholder;
 use BrizyPlaceholders\ContextInterface;
 
-class SermonDetailPlaceholder extends PlaceholderAbstract
+class SermonDetailPlaceholder extends PlaceholderAbstract implements PrefetchableInterface
 {
     const NAME = 'ekk_sermon_detail';
+
+	public function getPrefetchQueries( ContentPlaceholder $placeholder ): array
+	{
+		$options = [
+			'show_image'                => false,
+			'show_video'                => false,
+			'show_audio'                => false,
+			'show_inline_video'         => false,
+			'show_inline_audio'         => false,
+			'show_media_links_video'    => false,
+			'show_media_links_audio'    => false,
+			'show_media_links_download' => false,
+			'show_media_links_notes'    => false,
+			'show_title'                => false,
+			'show_date'                 => false,
+			'show_category'             => false,
+			'show_group'                => false,
+			'show_series'               => false,
+			'show_preacher'             => false,
+			'show_passage'              => false,
+			'show_meta_headings'        => false,
+			'show_preview'              => false,
+			'sermons_recent'            => '',
+			'previous_page'             => false,
+			'show_meta_icons'           => false
+		];
+
+		$settings = array_merge( $options, $placeholder->getAttributes() );
+
+		if ( ! empty( $_GET['mc-slug'] ) ) {
+			$slug = $_GET['mc-slug'];
+		} elseif ( $settings['sermons_recent'] ) {
+			$slug = $settings['sermons_recent'];
+		} else {
+			return [
+				[
+					'module'      => 'sermon',
+					'display'     => 'list',
+					'order'       => 'recent',
+					'howmany'     => 1,
+					'emailencode' => 'no',
+					'show'        => "__audioplayer__",
+				],
+			];
+		}
+
+		return [
+			[
+				'module'      => 'sermon',
+				'display'     => 'detail',
+				'find'        => $slug,
+				'emailencode' => 'no',
+				'show'        => "__audioplayer__",
+			],
+		];
+	}
 
 	public function echoValue( ContextInterface $context, ContentPlaceholder $placeholder )
 	{

--- a/src/Placeholder/SermonFeaturedPlaceholder.php
+++ b/src/Placeholder/SermonFeaturedPlaceholder.php
@@ -6,11 +6,99 @@ use BrizyEkklesia\HelperTrait;
 use BrizyPlaceholders\ContentPlaceholder;
 use BrizyPlaceholders\ContextInterface;
 
-class SermonFeaturedPlaceholder extends PlaceholderAbstract
+class SermonFeaturedPlaceholder extends PlaceholderAbstract implements PrefetchableInterface
 {
     use HelperTrait;
 
     const NAME = 'ekk_sermon_featured';
+
+    public function getPrefetchQueries(ContentPlaceholder $placeholder): array
+    {
+        $options = [
+            'show_image'              => false,
+            'show_video'              => false,
+            'show_audio'              => false,
+            'show_inline_video'       => false,
+            'show_inline_audio'       => false,
+            'show_title'              => false,
+            'show_date'               => false,
+            'show_category'           => false,
+            'show_group'              => false,
+            'show_series'             => false,
+            'show_preacher'           => false,
+            'show_passage'            => false,
+            'show_meta_headings'      => false,
+            'show_content'            => false,
+            'sermon_latest'           => false,
+            'sermon_recent_list'      => 'none',
+            'sermon_slug'             => false,
+            'category'                => 'all',
+            'group'                   => 'all',
+            'series'                  => 'all',
+            'features'                => '',
+            'nonfeatures'             => '',
+            'show_media_links'        => false,
+            'show_preview'            => false,
+            'detail_page_button_text' => false,
+            'detail_page'             => false,
+            'show_meta_icons'         => false
+        ];
+
+        $settings = array_merge($options, $placeholder->getAttributes());
+
+        $sermon_recent_list = $settings['sermon_recent_list'] != 'none' ? $settings['sermon_recent_list'] : '';
+        $category           = $settings['category'] != 'all' ? $settings['category'] : '';
+        $group              = $settings['group'] != 'all' ? $settings['group'] : '';
+        $series             = $settings['series'] != 'all' ? $settings['series'] : '';
+        $features           = $settings['features'];
+        $nonfeatures        = $settings['nonfeatures'];
+        $slug               = false;
+
+        if ($features) {
+            $nonfeatures = '';
+        } elseif ($nonfeatures) {
+            $features = '';
+        }
+
+        if ($settings['sermon_latest']) {
+            return [
+                [
+                    'module'        => 'sermon',
+                    'display'       => 'list',
+                    'order'         => 'recent',
+                    'howmany'       => 1,
+                    'find_category' => $category,
+                    'find_group'    => $group,
+                    'find_series'   => $series,
+                    'features'      => $features,
+                    'nonfeatures'   => $nonfeatures,
+                    'emailencode'   => 'no',
+                    'show'          => "__audioplayer__",
+                ],
+            ];
+        }
+
+        if ($settings['sermon_slug']) {
+            $slug = $settings['sermon_slug'];
+        } elseif ($sermon_recent_list != '') {
+            $slug = $sermon_recent_list;
+        }
+
+        if ($slug) {
+            return [
+                [
+                    'module'      => 'sermon',
+                    'display'     => 'detail',
+                    'find'        => $slug,
+                    'emailencode' => 'no',
+                    'show'        => "__videoplayer fullscreen='true'__",
+                    'show'        => "__audioplayer__",
+                ],
+            ];
+        }
+
+        return [];
+    }
 
     public function echoValue(ContextInterface $context, ContentPlaceholder $placeholder)
     {

--- a/src/Placeholder/SermonLayoutPlaceholder.php
+++ b/src/Placeholder/SermonLayoutPlaceholder.php
@@ -6,11 +6,141 @@ use BrizyEkklesia\HelperTrait;
 use BrizyPlaceholders\ContentPlaceholder;
 use BrizyPlaceholders\ContextInterface;
 
-class SermonLayoutPlaceholder extends PlaceholderAbstract
+class SermonLayoutPlaceholder extends PlaceholderAbstract implements PrefetchableInterface
 {
     use HelperTrait;
 
     const NAME = 'ekk_sermon_layout';
+
+    public function getPrefetchQueries(ContentPlaceholder $placeholder): array
+    {
+        $options = [
+            'show_group_filter'       => false,
+            'group_filter_heading'    => 'Group',
+            'show_category_filter'    => false,
+            'category_filter_heading' => 'Category',
+            'show_series_filter'      => false,
+            'series_filter_heading'   => 'Series',
+            'show_speaker_filter'     => false,
+            'speaker_filter_heading'  => 'Speaker',
+            'show_search'             => false,
+            'search_placeholder'      => 'Search',
+            'search_value'            => '',
+            'column_count'            => 3,
+            'column_count_tablet'     => 2,
+            'column_count_mobile'     => 1,
+            'show_pagination'         => false,
+            'show_images'             => true,
+            'show_video'              => false,
+            'show_audio'              => true,
+            'show_inline_video'       => true,
+            'show_inline_audio'       => true,
+            'show_media_links'        => true,
+            'show_title'              => true,
+            'show_date'               => true,
+            'show_category'           => true,
+            'show_group'              => true,
+            'show_series'             => true,
+            'show_preacher'           => true,
+            'show_passage'            => true,
+            'show_meta_headings'      => false,
+            'show_preview'            => false,
+            'detail_page_button_text' => false,
+            'howmany'                 => 9,
+            'sticky_space'            => 0,
+            'defaultCategory'         => '',
+            'show_meta_icons'         => false,
+            'parent_category'         => '',
+            'group_slug'              => '',
+        ];
+
+        $settings = array_merge($options, $placeholder->getAttributes());
+
+        $page            = isset($_GET['mc-page']) ? $_GET['mc-page'] : 1;
+        $category_filter = isset($_GET['mc-category']) ? $_GET['mc-category'] : '';
+        $requestGroup    = $_GET['mc-group'] ?? false;
+        $series_filter   = isset($_GET['mc-series']) ? $_GET['mc-series'] : '';
+        $speaker_filter  = isset($_GET['mc-speaker']) ? $_GET['mc-speaker'] : '';
+        $search          = $_GET['mc-search'] ?? '';
+
+        if (empty($_GET)) {
+            $search = $settings['search_value'];
+        }
+
+        if (!isset($_GET['mc-category']) && $settings['defaultCategory']) {
+            $category_filter = $settings['defaultCategory'];
+        }
+
+        $queries = [];
+
+        if ($settings['show_category_filter']) {
+            $queries[] = [
+                'module'     => 'sermon',
+                'order'      => 'title',
+                'display'    => 'categories',
+                'find_group' => $settings['group_slug'] ?: $requestGroup,
+            ];
+        }
+
+        if ($settings['show_group_filter'] && !$settings['group_slug']) {
+            $queries[] = [
+                'module'  => 'sermon',
+                'display' => 'list',
+                'groupby' => 'group',
+                'order'   => 'title',
+            ];
+        }
+
+        if ($settings['show_series_filter']) {
+            $queries[] = [
+                'module'     => 'sermon',
+                'display'    => 'list',
+                'groupby'    => 'series',
+                'order'      => 'title',
+                'find_group' => $settings['group_slug'] ?: $requestGroup
+            ];
+        }
+
+        if ($settings['show_speaker_filter']) {
+            $queries[] = [
+                'module'     => 'sermon',
+                'display'    => 'list',
+                'groupby'    => 'preacher',
+                'order'      => 'title',
+                'find_group' => $settings['group_slug'] ?: $requestGroup
+            ];
+        }
+
+        if (!empty($search)) {
+            $queries[] = [
+                'module'        => 'search',
+                'display'       => 'results',
+                'howmany'       => (int)$settings['howmany'],
+                'offset'        => ($page - 1) * (int)$settings['howmany'],
+                'keywords'      => $search,
+                'find_module'   => 'sermon',
+                'after_show'    => '__pagination__',
+                'find_category' => $category_filter,
+            ];
+        } else {
+            $queries[] = [
+                'module'        => 'sermon',
+                'display'       => 'list',
+                'order'         => 'recent',
+                'emailencode'   => 'no',
+                'page'          => $page,
+                'howmany'       => $settings['howmany'],
+                'find_category' => $category_filter,
+                'find_group'    => $settings['group_slug'] ?: $requestGroup,
+                'find_series'   => $series_filter,
+                'find_preacher' => $speaker_filter,
+                'show'          => "__audioplayer__",
+                'after_show'    => '__pagination__'
+            ];
+        }
+
+        return $queries;
+    }
 
     public function echoValue(ContextInterface $context, ContentPlaceholder $placeholder)
     {

--- a/src/Placeholder/SermonListPlaceholder.php
+++ b/src/Placeholder/SermonListPlaceholder.php
@@ -5,9 +5,41 @@ namespace BrizyEkklesia\Placeholder;
 use BrizyPlaceholders\ContentPlaceholder;
 use BrizyPlaceholders\ContextInterface;
 
-class SermonListPlaceholder extends PlaceholderAbstract
+class SermonListPlaceholder extends PlaceholderAbstract implements PrefetchableInterface
 {
     const NAME = 'ekk_sermon_list';
+
+    public function getPrefetchQueries(ContentPlaceholder $placeholder): array
+    {
+        $attributes = $placeholder->getAttributes();
+
+        $features    = empty($attributes['features']) ? '' : 'features';
+        $nonfeatures = empty($attributes['nonfeatures']) ? '' : 'nonfeatures';
+
+        if ($features) {
+            $nonfeatures = '';
+        } elseif ($nonfeatures) {
+            $features = '';
+        }
+
+        return [
+            [
+                'module'        => 'sermon',
+                'display'       => 'list',
+                'order'         => 'recent',
+                'emailencode'   => 'no',
+                'howmany'       => isset($attributes['howmany']) ? intval(round($attributes['howmany'])) : 9,
+                'page'          => isset($_GET['mc-page']) ? $_GET['mc-page'] : 1,
+                'find_category' => (isset($attributes['category']) && $attributes['category'] != 'all') ? $attributes['category'] : '',
+                'find_group'    => (isset($attributes['group']) && $attributes['group'] != 'all') ? $attributes['group'] : '',
+                'find_series'   => (isset($attributes['series']) && $attributes['series'] != 'all') ? $attributes['series'] : '',
+                'features'      => $features,
+                'nonfeatures'   => $nonfeatures,
+                'show'          => "__audioplayer__",
+                'after_show'    => '__pagination__',
+            ],
+        ];
+    }
 
     public function getValue(ContextInterface $context, ContentPlaceholder $placeholder)
     {

--- a/src/Placeholder/StaffDetailPlaceholder.php
+++ b/src/Placeholder/StaffDetailPlaceholder.php
@@ -5,9 +5,58 @@ namespace BrizyEkklesia\Placeholder;
 use BrizyPlaceholders\ContentPlaceholder;
 use BrizyPlaceholders\ContextInterface;
 
-class StaffDetailPlaceholder extends PlaceholderAbstract
+class StaffDetailPlaceholder extends PlaceholderAbstract implements PrefetchableInterface
 {
     const NAME = 'ekk_staff_detail';
+
+    public function getPrefetchQueries(ContentPlaceholder $placeholder): array
+    {
+        $settings = array_merge([
+            'staff_recent'       => '',
+            'show_image'         => true,
+            'show_title'         => true,
+            'show_position'      => true,
+            'show_groups'        => false,
+            'show_phone_work'    => false,
+            'show_phone_cell'    => false,
+            'show_email'         => true,
+            'show_facebook'      => true,
+            'show_twitter'       => true,
+            'show_instagram'     => false,
+            'show_website'       => false,
+            'show_rss'           => false,
+            'show_meta_headings' => true,
+            'show_about'         => true,
+            'show_meta_icons'    => false,
+            'show_previous_page' => false,
+            'show_full_email'    => false,
+        ], $placeholder->getAttributes());
+
+        $slug = isset($_GET['mc-slug']) ? $_GET['mc-slug'] : $settings['staff_recent'];
+
+        if (!$slug) {
+            return [
+                [
+                    'module'      => 'member',
+                    'display'     => 'list',
+                    'order'       => 'position',
+                    'howmany'     => 1,
+                    'emailencode' => 'no',
+                    'restrict'    => 'no',
+                ],
+            ];
+        }
+
+        return [
+            [
+                'module'      => 'member',
+                'display'     => 'profile',
+                'emailencode' => 'no',
+                'restrict'    => 'no',
+                'find'        => $slug,
+            ],
+        ];
+    }
 
     public function echoValue(ContextInterface $context, ContentPlaceholder $placeholder)
     {

--- a/src/Placeholder/StaffFeaturedPlaceholder.php
+++ b/src/Placeholder/StaffFeaturedPlaceholder.php
@@ -5,9 +5,59 @@ namespace BrizyEkklesia\Placeholder;
 use BrizyPlaceholders\ContentPlaceholder;
 use BrizyPlaceholders\ContextInterface;
 
-class StaffFeaturedPlaceholder extends PlaceholderAbstract
+class StaffFeaturedPlaceholder extends PlaceholderAbstract implements PrefetchableInterface
 {
     const NAME = 'ekk_staff_featured';
+
+    public function getPrefetchQueries(ContentPlaceholder $placeholder): array
+    {
+        $settings = array_merge([
+            'staff_slug'         => '',
+            'show_latest_staff'  => false,
+            'show_image'         => true,
+            'show_title'         => true,
+            'show_position'      => true,
+            'show_groups'        => false,
+            'show_phone_work'    => false,
+            'show_phone_cell'    => false,
+            'show_email'         => true,
+            'show_facebook'      => true,
+            'show_twitter'       => true,
+            'show_instagram'     => false,
+            'show_website'       => false,
+            'show_rss'           => false,
+            'show_meta_headings' => true,
+            'show_about'         => true,
+            'show_meta_icons'    => false,
+            'show_full_email'    => false,
+            'show_previous_page' => false,
+            'detail_page_button_text' => false,
+            'detail_page'             => false,
+        ], $placeholder->getAttributes());
+
+        if (!$settings['staff_slug']) {
+            return [
+                [
+                    'module'      => 'member',
+                    'display'     => 'list',
+                    'order'       => 'position',
+                    'howmany'     => 1,
+                    'emailencode' => 'no',
+                    'restrict'    => 'no',
+                ],
+            ];
+        }
+
+        return [
+            [
+                'module'      => 'member',
+                'display'     => 'profile',
+                'emailencode' => 'no',
+                'restrict'    => 'no',
+                'find'        => $settings['staff_slug'],
+            ],
+        ];
+    }
 
     public function echoValue(ContextInterface $context, ContentPlaceholder $placeholder)
     {

--- a/src/Placeholder/StaffLayoutPlaceholder.php
+++ b/src/Placeholder/StaffLayoutPlaceholder.php
@@ -5,9 +5,91 @@ namespace BrizyEkklesia\Placeholder;
 use BrizyPlaceholders\ContentPlaceholder;
 use BrizyPlaceholders\ContextInterface;
 
-class StaffLayoutPlaceholder extends PlaceholderAbstract
+class StaffLayoutPlaceholder extends PlaceholderAbstract implements PrefetchableInterface
 {
     const NAME = 'ekk_staff_layout';
+
+    public function getPrefetchQueries(ContentPlaceholder $placeholder): array
+    {
+        $options = [
+            'show_group_filter' => true,
+            'show_search' => true,
+            'show_images' => true,
+            'show_title' => true,
+            'show_position' => true,
+            'show_groups' => true,
+            'show_phone_work' => false,
+            'show_phone_cell' => false,
+            'show_email' => false,
+            'show_facebook' => false,
+            'show_twitter' => false,
+            'show_website' => false,
+            'show_instagram' => false,
+            'show_meta_headings' => false,
+            'show_full_email' => false,
+            'show_res' => false,
+            'detail_page_button_text' => 'Read More',
+            'detail_page' => '',
+            'show_meta_icons' => false,
+            'search_placeholder' => 'Search',
+            'group_filter_heading' => 'Group',
+            'howmany' => 9,
+            'show_pagination' => true,
+            'series' => '',
+        ];
+
+        $settings = array_merge($options, $placeholder->getAttributes());
+
+        $series_filter = ($settings['series'] && $settings['series'] != '') ? $settings['series'] : false;
+
+        $queries = [];
+
+        if ($settings['show_group_filter']) {
+            $groups_queryArr = [
+                'module' => 'group',
+                'display' => 'list',
+            ];
+
+            if ($series_filter) {
+                $groups_queryArr['find_series'] = $series_filter;
+            }
+
+            $queries[] = $groups_queryArr;
+        }
+
+        if (isset($_GET['mc-search_term'])) {
+            $queries[] = [
+                'module' => 'member',
+                'display' => 'list',
+                'order' => 'position',
+                'emailencode' => 'no',
+                'restrict' => 'no',
+            ];
+        } else {
+            $queryArr = [
+                'module' => 'member',
+                'display' => 'list',
+                'order' => 'position',
+                'emailencode' => 'no',
+                'restrict' => 'no',
+            ];
+
+            $group_filter = isset($_GET['mc-group']) ? $_GET['mc-group'] : '';
+
+            if ($group_filter) {
+                $queryArr['find_group'] = $group_filter;
+            }
+
+            if ($series_filter) {
+                $queryArr['find_group_series'] = $series_filter;
+                $queryArr['groupby'] = 'none';
+            }
+
+            $queries[] = $queryArr;
+        }
+
+        return $queries;
+    }
 
     public function echoValue(ContextInterface $context, ContentPlaceholder $placeholder)
     {

--- a/src/Placeholder/StaffListPlaceholder.php
+++ b/src/Placeholder/StaffListPlaceholder.php
@@ -5,9 +5,45 @@ namespace BrizyEkklesia\Placeholder;
 use BrizyPlaceholders\ContentPlaceholder;
 use BrizyPlaceholders\ContextInterface;
 
-class StaffListPlaceholder extends PlaceholderAbstract
+class StaffListPlaceholder extends PlaceholderAbstract implements PrefetchableInterface
 {
     const NAME = 'ekk_staff_list';
+
+    public function getPrefetchQueries(ContentPlaceholder $placeholder): array
+    {
+        $settings = array_merge([
+            'group' => '',
+            'show_images' => true,
+            'show_title' => true,
+            'show_position' => true,
+            'show_groups' => false,
+            'show_phone_work' => false,
+            'show_phone_cell' => false,
+            'show_email' => false,
+            'show_facebook' => false,
+            'show_twitter' => false,
+            'show_website' => false,
+            'show_instagram' => false,
+            'show_meta_headings' => false,
+            'show_meta_icons' => false,
+            'howmany' => 9,
+            'detail_page_button_text' => '',
+            'detail_page' => '',
+            'show_full_email' => false,
+            'show_pagination' => true,
+        ], $placeholder->getAttributes());
+
+        return [
+            [
+                'module' => 'member',
+                'display' => 'list',
+                'order' => 'position',
+                'emailencode' => 'no',
+                'restrict' => 'no',
+                'find_group' => $settings['group'],
+            ],
+        ];
+    }
 
     public function echoValue(ContextInterface $context, ContentPlaceholder $placeholder)
     {


### PR DESCRIPTION
`MonkCms` gets a request-scoped response cache plus `prefetch()` that warms it via the new `Cms::getMultiple` (parallel curl_multi). Each placeholder declares the deterministic queries it will run through `PrefetchableInterface::getPrefetchQueries`, so the host app can collect them after extraction and fire them all at once before rendering.

- Queries whose params depend on a previous API response are not declared and keep running sequentially on cache miss.
- `echoValue` is untouched in every placeholder — zero render-behavior change.
- The cache also dedupes identical queries within a request.

Measured on a placeholder-heavy page (project 4257962 home): TTFB 21-33s → ~4.4s, byte-identical HTML.

Requires brizybuilder/monkcms-php `^1.1` (brizybuilder/monkcms-php#2). Merge order: monkcms-php first, tag `1.1.0`, then this. The Brizy-Cloud side needs a small `Context::afterExtract` change to trigger the prefetch — separate PR after these merge.